### PR TITLE
Fixed asciidoc markup for link

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -49,8 +49,8 @@ projects can be seen in the following illustration:
 image::project-graph.png[Project Graph]
 
 If the `api` and `implementation` configurations are new to you, read more
-about the
-[Java Library Plugin](https://docs.gradle.org/current/userguide/java_library_plugin.html)
+about the https://docs.gradle.org/current/userguide/java_library_plugin.html
+[Java Library Plugin] 
 added in Gradle 3.4.
 
 You can clone the project and run the original program to see its output:


### PR DESCRIPTION
Was using markdown markup before which does not render nicely in asciidoc.