### PR TITLE
Fix overuse of doFirst and afterEvaluate

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -265,17 +265,11 @@ reuse the same code later for other modules without having to change it.
 <2> Clears the `classpath` property by creating an empty file collection
 
 When compiling a Java 9 module, you want to use `--module-path` instead of
-`--classpath` to read your dependencies. So in the `doFirst` block, you are
-clearing out the `classpath` property of the task and adding a compiler
-argument.
+`--classpath` to read your dependencies.
 
-* `--module-path` is set to the value that would have been the `classpath`. This
+* `--module-path` is set to the value of the `classpath`. This
   makes sense because the classpath already has any jars or class output
   directories of libraries on which you depend.
-
-NOTE: The reason you modify `options.compilerArgs` inside the `doFirst` block
-instead of in the configuration block of the `compileJava` task is because you
-only want resolve the `compileClasspath` configuration when executing that task.
 
 === Modify the `compileTestJava` task to locally alter the module
 

--- a/src/0-original/build.gradle
+++ b/src/0-original/build.gradle
@@ -1,7 +1,5 @@
 subprojects {
-    afterEvaluate {
-        repositories {
-            jcenter()
-        }
+    repositories {
+        jcenter()
     }
 }

--- a/src/1-single-module/actors/build.gradle
+++ b/src/1-single-module/actors/build.gradle
@@ -13,41 +13,32 @@ ext.moduleName = 'org.gradle.actors' // <1>
 
 compileJava {
     inputs.property("moduleName", moduleName)
-    doFirst {
-        options.compilerArgs = [
-            '--module-path', classpath.asPath,
-        ]
-        classpath = files()  // <2>
-    }
+    options.compilerArgs = [
+        '--module-path', classpath.asPath // <2>
+    ]
 }
 // end::compileJava[]
 
 // tag::compileTestJava[]
 compileTestJava {
     inputs.property("moduleName", moduleName)
-    doFirst {
         options.compilerArgs = [
-            '--module-path', classpath.asPath, // <1>
-            '--add-modules', 'junit',  // <2>
-            '--add-reads', "$moduleName=junit", // <3>
-            '--patch-module', "$moduleName=" + files(sourceSets.test.java.srcDirs).asPath, // <4>
-        ]
-        classpath = files()
-    }
+        '--module-path', classpath.asPath, // <1>
+        '--add-modules', 'junit',  // <2>
+        '--add-reads', "$moduleName=junit", // <3>
+        '--patch-module', "$moduleName=" + files(sourceSets.test.java.srcDirs).asPath, // <4>
+    ]
 }
 // end::compileTestJava[]
 
 // tag::test[]
 test {
     inputs.property("moduleName", moduleName)
-    doFirst {
-        jvmArgs = [
-            '--module-path', classpath.asPath, // <1>
-            '--add-modules', 'ALL-MODULE-PATH', // <2>
-            '--add-reads', "$moduleName=junit", // <3>
-            '--patch-module', "$moduleName=" + files(sourceSets.test.java.outputDir).asPath, // <4>
-        ]
-        classpath = files()
-    }
+    jvmArgs = [
+        '--module-path', classpath.asPath, // <1>
+        '--add-modules', 'ALL-MODULE-PATH', // <2>
+        '--add-reads', "$moduleName=junit", // <3>
+        '--patch-module', "$moduleName=" + files(sourceSets.test.java.outputDir).asPath, // <4>
+    ]
 }
 // end::test[]

--- a/src/1-single-module/build.gradle
+++ b/src/1-single-module/build.gradle
@@ -1,9 +1,9 @@
 subprojects {
-    afterEvaluate {
-        repositories {
-            jcenter()
-        }
+    repositories {
+        jcenter()
+    }
 
+    afterEvaluate {
         // tag::autoModuleName[]
         jar {
             inputs.property("moduleName", moduleName)

--- a/src/2-all-modules/build.gradle
+++ b/src/2-all-modules/build.gradle
@@ -1,43 +1,34 @@
 subprojects {
-    afterEvaluate {
-        repositories {
-            jcenter()
-        }
+    repositories {
+        jcenter()
+    }
 
+    afterEvaluate {
         compileJava {
             inputs.property("moduleName", moduleName)
-            doFirst {
-                options.compilerArgs = [
-                    '--module-path', classpath.asPath,
-                ]
-                classpath = files()
-            }
+            options.compilerArgs = [
+                '--module-path', classpath.asPath,
+            ]
         }
 
         compileTestJava {
             inputs.property("moduleName", moduleName)
-            doFirst {
-                options.compilerArgs = [
-                    '--module-path', classpath.asPath,
-                    '--add-modules', 'junit',
-                    '--add-reads', "$moduleName=junit",
-                    '--patch-module', "$moduleName=" + files(sourceSets.test.java.srcDirs).asPath,
-                ]
-                classpath = files()
-            }
+            options.compilerArgs = [
+                '--module-path', classpath.asPath,
+                '--add-modules', 'junit',
+                '--add-reads', "$moduleName=junit",
+                '--patch-module', "$moduleName=" + files(sourceSets.test.java.srcDirs).asPath,
+            ]
         }
 
         test {
             inputs.property("moduleName", moduleName)
-            doFirst {
-                jvmArgs = [
-                    '--module-path', classpath.asPath,
-                    '--add-modules', 'ALL-MODULE-PATH',
-                    '--add-reads', "$moduleName=junit",
-                    '--patch-module', "$moduleName=" + files(sourceSets.test.java.outputDir).asPath,
-                ]
-                classpath = files()
-            }
+            jvmArgs = [
+                '--module-path', classpath.asPath,
+                '--add-modules', 'ALL-MODULE-PATH',
+                '--add-reads', "$moduleName=junit",
+                '--patch-module', "$moduleName=" + files(sourceSets.test.java.outputDir).asPath,
+            ]
         }
     }
 }

--- a/src/3-application/build.gradle
+++ b/src/3-application/build.gradle
@@ -1,42 +1,33 @@
 subprojects {
-    afterEvaluate {
-        repositories {
-            jcenter()
-        }
+    repositories {
+        jcenter()
+    }
 
+    afterEvaluate {
         compileJava {
-            doFirst {
-                options.compilerArgs = [
-                    '--module-path', classpath.asPath,
-                ]
-                classpath = files()
-            }
+            options.compilerArgs = [
+                '--module-path', classpath.asPath,
+            ]
         }
 
         compileTestJava {
             inputs.property("moduleName", moduleName)
-            doFirst {
-                options.compilerArgs = [
-                    '--module-path', classpath.asPath,
-                    '--add-modules', 'junit',
-                    '--add-reads', "$moduleName=junit",
-                    '--patch-module', "$moduleName=" + files(sourceSets.test.java.srcDirs).asPath,
-                ]
-                classpath = files()
-            }
+            options.compilerArgs = [
+                '--module-path', classpath.asPath,
+                '--add-modules', 'junit',
+                '--add-reads', "$moduleName=junit",
+                '--patch-module', "$moduleName=" + files(sourceSets.test.java.srcDirs).asPath,
+            ]
         }
 
         test {
             inputs.property("moduleName", moduleName)
-            doFirst {
-                jvmArgs = [
-                    '--module-path', classpath.asPath,
-                    '--add-modules', 'ALL-MODULE-PATH',
-                    '--add-reads', "$moduleName=junit",
-                    '--patch-module', "$moduleName=" + files(sourceSets.test.java.outputDir).asPath,
-                ]
-                classpath = files()
-            }
+            jvmArgs = [
+                '--module-path', classpath.asPath,
+                '--add-modules', 'ALL-MODULE-PATH',
+                '--add-reads', "$moduleName=junit",
+                '--patch-module', "$moduleName=" + files(sourceSets.test.java.outputDir).asPath,
+            ]
         }
     }
 }

--- a/src/3-application/fairy/build.gradle
+++ b/src/3-application/fairy/build.gradle
@@ -19,26 +19,20 @@ mainClassName = "$moduleName/org.gradle.fairy.app.StoryTeller" // <1>
 
 run {
     inputs.property("moduleName", moduleName)
-    doFirst {
-        jvmArgs = [
-            '--module-path', classpath.asPath,
-            '--module', mainClassName // <2>
-        ]
-        classpath = files()
-    }
+    jvmArgs = [
+        '--module-path', classpath.asPath,
+        '--module', mainClassName // <2>
+    ]
 }
 // end::run[]
 
 // tag::startScripts[]
 startScripts {
     inputs.property("moduleName", moduleName)
-    doFirst {
-        classpath = files()
-        defaultJvmOpts = [
-            '--module-path', 'APP_HOME_LIBS',  // <1>
-            '--module', mainClassName
-        ]
-    }
+    defaultJvmOpts = [
+        '--module-path', 'APP_HOME_LIBS',  // <1>
+        '--module', mainClassName
+    ]
     doLast{
         def bashFile = new File(outputDir, applicationName)
         String bashContent = bashFile.text

--- a/src/4-plugin/build.gradle
+++ b/src/4-plugin/build.gradle
@@ -1,7 +1,5 @@
 subprojects {
-    afterEvaluate {
-        repositories {
-            jcenter()
-        }
+    repositories {
+        jcenter()
     }
 }


### PR DESCRIPTION
Remove overuse of `doFirst` and `afterEvaluate` and needless fiddling with the classpath.

We found these snippets copy&pasted in our code and felt that others might profit from a correction as well.